### PR TITLE
Mostrar carátulas (previews) de los mra y mgl en el menú OSD del MiSTer (autor Renan @r3n4ncps)

### DIFF
--- a/cfg.cpp
+++ b/cfg.cpp
@@ -97,6 +97,9 @@ static const ini_var_t ini_vars[] =
 	{ "SHMASK_MODE_DEFAULT", (void*)(&(cfg.shmask_mode_default)), UINT8, 0, 255 },
 	{ "PRESET_DEFAULT", (void*)(&(cfg.preset_default)), STRING, 0, sizeof(cfg.preset_default) - 1 },
 	{ "LOG_FILE_ENTRY", (void*)(&(cfg.log_file_entry)), UINT8, 0, 1 },
+	//BEGIN WALLPAPERS
+	{ "GAME_WALLPAPERS", (void*)(&(cfg.game_wallpapers)), UINT8, 0, 1 },
+	//END WALLPAPERS
 	{ "BT_AUTO_DISCONNECT", (void*)(&(cfg.bt_auto_disconnect)), UINT32, 0, 180 },
 	{ "BT_RESET_BEFORE_PAIR", (void*)(&(cfg.bt_reset_before_pair)), UINT8, 0, 1 },
 	{ "WAITMOUNT", (void*)(&(cfg.waitmount)), STRING, 0, sizeof(cfg.waitmount) - 1 },

--- a/cfg.h
+++ b/cfg.h
@@ -54,6 +54,9 @@ typedef struct {
 	uint8_t browse_expand;
 	uint8_t logo;
 	uint8_t log_file_entry;
+	//BEGIN WALLPAPERS
+	uint8_t game_wallpapers;
+	//END WALLPAPERS
 	uint8_t shmask_mode_default;
 	int bt_auto_disconnect;
 	int bt_reset_before_pair;

--- a/menu.cpp
+++ b/menu.cpp
@@ -5349,6 +5349,12 @@ void HandleUI(void)
 			MakeFile("/tmp/FULLPATH", selPath);
 			MakeFile("/tmp/FILESELECT", "active");
 		}
+		//BEGIN WALLPAPERS
+		if (cfg.game_wallpapers && user_io_status_get("[3:1]") == 1)
+		{
+			video_menu_bg(user_io_status_get("[3:1]"));
+		}
+		//END WALLPAPERS
 		break;
 
 	case MENU_FILE_SELECT2:

--- a/video.cpp
+++ b/video.cpp
@@ -3532,6 +3532,51 @@ static Imlib_Image load_bg()
 		if (!FileExists(fname)) fname = 0;
 	}
 
+	//BEGIN WALLPAPERS
+	if (cfg.game_wallpapers)
+	{
+		char bgdir[32];
+		int alt = altcfg();
+		sprintf(bgdir, "wallpapers_alt_%d", alt);
+		if (alt == 1 && !PathIsDir(bgdir)) strcpy(bgdir, "wallpapers_alt");
+		if (alt <= 0 || !PathIsDir(bgdir)) strcpy(bgdir, "wallpapers");
+		if (PathIsDir(bgdir))
+		{
+			auto selectedItem = flist_SelectedItem();
+			char fullpath[256];
+			bool fileExists = false;
+
+			if (selectedItem != nullptr)
+			{
+				char* altname = selectedItem->altname;
+				snprintf(fullpath, sizeof(fullpath), "%s/%s.png", bgdir, altname);
+				if (FileExists(fullpath))
+				{
+					fileExists = true;
+				}
+				else
+				{
+					snprintf(fullpath, sizeof(fullpath), "%s/%s.jpg", bgdir, altname);
+					if (FileExists(fullpath))
+					{
+						fileExists = true;
+					}
+				}
+			}
+
+			if (!fileExists)
+			{
+				sprintf(fullpath, "%s/default.png", bgdir);
+				if (!FileExists(fullpath))
+				{
+					sprintf(fullpath, "%s/default.jpg", bgdir);
+				}
+			}
+			fname = fullpath;
+		}
+	}
+	//END WALLPAPERS
+
 	if (!fname)
 	{
 		static char bgdir[128];
@@ -3655,6 +3700,9 @@ void video_menu_bg(int n, int idle)
 			{
 			case 1:
 				if (!menubg) menubg = load_bg();
+				//BEGIN WALLPAPERS
+				if (!menubg || cfg.game_wallpapers) menubg = load_bg();
+				//END WALLPAPERS
 				if (menubg)
 				{
 					imlib_context_set_image(menubg);


### PR DESCRIPTION
Alternativa relacionada con el frontend Zaparoo hecha por Renan (@r3n4ncps) para mostrar carátulas de juegos en el menú OSD del MiSTer.
Para utilizarlo:
1.- Añade las siguiente líneas al final del archivo mister.ini:
game_wallpapers=1.
[Menu]
direct_video=1
video_mode=640,30,60,70,240,4,4,14,12587
2.- Con la Mister encendida, conéctale un teclado y pulsa la tecla f1 varias veces para quitar el ruido blanco de fondo de OSD y que se activen los Wallpapers. 
Notas:
1.- El nombre de la imagen debe ser el mismo que el del archivo .mgl, .mra.
2.- Define una imagen con el nombre default para que aparezca cuando no exista una imagen específica del juego. 
3.- Usa imágenes en resolución 640x480p o 320x240p para evitar ralentizaciones.
4.- Coloca todas las imágenes en el directorio wallpapers, en la raíz de la tarjeta microSD.